### PR TITLE
Fixed major concenptional Error. V 1.1

### DIFF
--- a/classes/roman_numeral_converter/main_cls.py
+++ b/classes/roman_numeral_converter/main_cls.py
@@ -24,7 +24,7 @@ class RomanNumeralConverter:
         number_of_digits = math.floor(temp) + 1
         return number_of_digits
 
-    def split_number_into_digits(self, number: int) -> list[int]:
+    def split_number_into_digits_and_exponent(self, number: int) -> list[int]:
         base = 10
         number_of_digits = self.calculate_number_of_digits(number, base)
 
@@ -33,7 +33,7 @@ class RomanNumeralConverter:
         for exponent in reversed(range(number_of_digits)):
             digit_number = math.floor(temp_number / base ** exponent) * base ** exponent
             temp_number -= digit_number
-            digit_list.append(digit_number)
+            digit_list.append((digit_number, exponent))
 
         return digit_list
 
@@ -55,11 +55,13 @@ class RomanNumeralConverter:
 
     def convert_to_numeral_string(self, base: int = 10) -> str:
         user_input = self.get_user_input()
-        digit_list = self.split_number_into_digits(user_input)
+        digit_exponent_list = self.split_number_into_digits_and_exponent(user_input)
         roman_numeral_string = ''
-        for digit in digit_list:
-            exponent = self.calculate_number_of_digits(digit, base)
-            string_for_digit = self.convert_digit_from_base_to_numeral_string(digit, base**(exponent-1))
+        for (digit, exponent) in digit_exponent_list:
+            string_for_digit = self.convert_digit_from_base_to_numeral_string(digit, base**(exponent))
             roman_numeral_string += string_for_digit
         return roman_numeral_string
 
+if __name__ == '__main__':
+    rmc = RomanNumeralConverter()
+    print(rmc.convert_to_numeral_string())

--- a/classes/roman_numeral_converter/tests/test_cls_rmc.py
+++ b/classes/roman_numeral_converter/tests/test_cls_rmc.py
@@ -23,13 +23,13 @@ class Test_RomanNumeralConverter(TestCase):
     def test_numeral_string_input_returned_as_integer_value(self, input):
         self.assertEqual(115, self.rmc.get_user_input())
 
-    def test_split_number_into_digit_list(self):
-        self.assertEqual([100, 10, 1], self.rmc.split_number_into_digits(111))
-        self.assertEqual([10, 1], self.rmc.split_number_into_digits(11))
-        self.assertEqual([50, 4], self.rmc.split_number_into_digits(54))
-        self.assertEqual([6], self.rmc.split_number_into_digits(6))
-        self.assertEqual([1000, 400, 80, 9], self.rmc.split_number_into_digits(1489))
-        self.assertEqual([800, 0, 0], self.rmc.split_number_into_digits(800))
+    def test_split_number_into_digits_and_exponents_list(self):
+        self.assertEqual([(100, 2), (10, 1) , (1, 0)], self.rmc.split_number_into_digits_and_exponent(111))
+        self.assertEqual([(10, 1), (1, 0)], self.rmc.split_number_into_digits_and_exponent(11))
+        self.assertEqual([(50, 1), (4, 0)], self.rmc.split_number_into_digits_and_exponent(54))
+        self.assertEqual([(6, 0)], self.rmc.split_number_into_digits_and_exponent(6))
+        self.assertEqual([(1000, 3), (400, 2), (80, 1), (9, 0)], self.rmc.split_number_into_digits_and_exponent(1489))
+        self.assertEqual([(800, 2), (0, 1), (0, 0)], self.rmc.split_number_into_digits_and_exponent(800))
 
     def test_convert_first_digit_to_numeral_string(self):
         base = 1
@@ -95,11 +95,13 @@ class Test_RomanNumeralConverter(TestCase):
         self.assertEqual(8, self.rmc.calculate_number_of_digits(255, base))
         self.assertEqual(10, self.rmc.calculate_number_of_digits(1023, base))
 
-    @mock.patch('builtins.input', side_effect=['11', '154', '1874'])
+    @mock.patch('builtins.input', side_effect=['11', '154', '1874', '10', '200'])
     def test_converting_combined_digits(self, input):
         self.assertEqual('XI', self.rmc.convert_to_numeral_string())
         self.assertEqual('CLIV', self.rmc.convert_to_numeral_string())
         self.assertEqual('MDCCCLXXIV', self.rmc.convert_to_numeral_string())
+        self.assertEqual('X', self.rmc.convert_to_numeral_string())
+        self.assertEqual('CC', self.rmc.convert_to_numeral_string())
     
 
 


### PR DESCRIPTION
After the digits were splitted into 1000, 100, 10, 1. A future exponent calculation via

```py
    def calculate_number_of_digits(self, number: int, base: int = 10) -> int:
        temp = math.log(number, base)
        number_of_digits = math.floor(temp) + 1
        return number_of_digits
```
was conceptional wrong, because the individual digits for each place could be 0.

The fix 1.1 provided a solution, which provided the exponents inside of the digit list. Thus, the individual digits, even if they were 0, were already delivered with the right exponent.